### PR TITLE
Removing color value from Friends.jsx Typography component

### DIFF
--- a/src/components/Friends.jsx
+++ b/src/components/Friends.jsx
@@ -12,6 +12,8 @@ import '../assets/Friends.css';
 // import Login from './Login';
 
 function Friends({toggle}) {
+
+  console.log(toggle)
   
     return (
       <div
@@ -41,7 +43,6 @@ function Friends({toggle}) {
               <CardContent>
                 <Typography
                   sx={{ fontSize: 14 }}
-                  color="text.[primary]"
                   gutterBottom
                 >
                   Friends

--- a/src/components/Friends.jsx
+++ b/src/components/Friends.jsx
@@ -12,8 +12,6 @@ import '../assets/Friends.css';
 // import Login from './Login';
 
 function Friends({toggle}) {
-
-  console.log(toggle)
   
     return (
       <div


### PR DESCRIPTION
Fixing bug according to issue - [BUG] Friends.jsx: Color in Typography #66

![image](https://user-images.githubusercontent.com/74624831/219945262-359fc084-88d8-456a-9201-c7900695f9c5.png)

I removed color property. @gbowne1 
