### PR TITLE
Added max-width and updated width to .Section-container and .Profile-container

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -90,7 +90,8 @@
 }
 
 .Section-container {
-    width: 90%;
+    width: 70%;
+    max-width: 1400px;
     min-height: 700px;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;

--- a/src/assets/Profile.css
+++ b/src/assets/Profile.css
@@ -9,7 +9,8 @@
 
 .Profile-container {
     background-color: beige;
-    width: 90%;
+    width: 70%;
+    max-width: 1400px;
     height: 700px;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;


### PR DESCRIPTION
Issue: [CSS] Fix the width of the components/panels #43

In order to set a max-width for the relevant components(.Section-container being the main container for components like Dashboard, Settings, etc.   And .Profile-container being the main container of User Profile component) I added a max-width of 1400px, which would leave 500px free for two 250px sidebars.

I also updated the width of 70% for these components to make sure that at least 30% of the screen is free for two 15% width sidebars.

The previous width for these components was 90%. I don't know if that width was required for any specific reason, but I reduced it in this solution as it only left 10% of the screen for the two sidebars.

If it's required that the width be left at 90% I can set it back.

For the moment this is how the solution looks with components using a 70% and 1400px max-width:

![image](https://user-images.githubusercontent.com/4129325/220950384-9017742e-beda-4d82-b14a-a2e0f240b21a.png)
