### PR TITLE
Login page labels dark mode

### DIFF
--- a/src/assets/Login.css
+++ b/src/assets/Login.css
@@ -1,30 +1,78 @@
 @import url("../variables.css");
 
-/* TODO: Update colors according to variables.css */
-
-.Login-header {
-	background-color: blue;
-}
-.Login-button {
-	align-items: right;
-	background-color: aqua;
-	float: right;
-	margin-top: 10px;
-	margin-right: 5px;
-	padding-right: 5px;
+.Login__container {
+  margin-top: 200px;
 }
 
-input[type="email"] {
-	border: 0;
-	padding: 0.625rem;
-	margin-top: 0.3125rem;
+.Login_loading-spinner {
+  position: relative;
+  top: 100px;
+  display: flex;
+  justify-content: center;
+  margin: 0 auto;
 }
 
-input[type="submit"] {
-	background-color: blue;
-	color: black;
-	cursor: pointer;
-	border: 0;
-	padding: 0.625rem 0.9375rem;
-	margin-top: 0.3125rem;
+.Login__theme-mode-switch {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid;
+  border-radius: 10px;
+  width: fit-content;
+  padding: 5px 10px;
+  margin: 0 auto 20px;
+}
+
+.Login__theme-mode-switch.light-mode {
+  border-color: var(--bg-dark-100);
+}
+
+.Login__theme-mode-switch.dark-mode {
+  border-color: var(--bg-light-100);
+}
+
+.Login__form {
+  border: 1px solid;
+  border-radius: 10px;
+  margin: 0 auto;
+  max-width: 600px;
+  padding: 20px;
+}
+
+.Login__form.light-mode {
+  border-color: var(--bg-dark-100) !important;
+}
+
+.Login__form.dark-mode {
+  border-color: var(--bg-light-100) !important;
+}
+
+.Login__textfield.dark-mode label {
+  color: var(--text-light-100) !important;
+}
+
+.Login__textfield.dark-mode input {
+  color: var(--text-light-100) !important;
+  background-color: var(--bg-dark-100);
+}
+
+.Login__textfield.dark-mode input:-webkit-autofill,
+.Login__textfield.dark-mode input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0px 1000px var(--bg-light-900) inset;
+}
+
+.Login__textfield.dark-mode fieldset {
+  border-color: var(--bg-light-100) !important;
+}
+
+.Login__form-panel button {
+  margin: 10px auto 20px;
+  width: 200px;
+  background-color: #ffc93d !important;
+}
+
+.Login__form-panel .subscribe,
+.Login__form-panel .login {
+  font-weight: bold;
+  cursor: pointer;
 }

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -32,6 +32,7 @@ import { createTheme, ThemeProvider } from "@mui/material/styles";
 
 import CustomAlert from "./CustomAlert";
 import { loadFromLocalStorage, saveToLocalStorage } from "../utils";
+import "../assets/Login.css";
 
 YupPassword(yup);
 
@@ -58,10 +59,6 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
       mode: themeMode ? "light" : "dark",
     },
   });
-
-  const lightDividerColor = "rgba(0, 0, 0, 0.3)";
-  const darkDividerColor = "rgba(255, 255, 255, 0.3)";
-  const dividerColor = themeMode === "light-mode" ? lightDividerColor : darkDividerColor;
 
   const inputChangeHandler = (value) => {
     setUserData(value);
@@ -192,23 +189,10 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Container
-        sx={{
-          marginTop: "200px",
-        }}
-      >
+      <Container className={`Login__container`}>
         <Box
           id="theme-mode-switch"
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            border: `1px solid ${dividerColor}`,
-            borderRadius: "10px",
-            width: "fit-content",
-            padding: "5px 10px",
-            margin: "0 auto 20px",
-          }}
+          className={`Login__theme-mode-switch ${themeMode}`}
         >
           <LightMode />
 
@@ -220,28 +204,11 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
         </Box>
 
         {showLoadingSpinner ? (
-          <Box
-            sx={{
-              position: "relative",
-              top: "100px",
-              display: "flex",
-              justifyContent: "center",
-              mx: "auto",
-            }}
-          >
+          <Box className={`Login_loading-spinner`}>
             <CircularProgress size={60} />
           </Box>
         ) : (
-          <Box
-            component="form"
-            sx={{
-              border: `1px solid ${dividerColor}`,
-              borderRadius: "10px",
-              mx: "auto",
-              maxWidth: "600px",
-              padding: "20px",
-            }}
-          >
+          <Box component="form" className={`Login__form ${themeMode}`}>
             <Stack spacing={2}>
               <CustomAlert
                 severity={alertOptions.severity}
@@ -252,6 +219,7 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
 
               <TextField
                 id="username"
+                className={`Login__textfield ${themeMode}`}
                 placeholder="Enter username"
                 label="Username"
                 variant="outlined"
@@ -269,6 +237,7 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
 
               <TextField
                 id="email"
+                className={`Login__textfield ${themeMode}`}
                 placeholder="Enter email"
                 label="Email"
                 variant="outlined"
@@ -282,6 +251,7 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
               />
 
               <FormControl
+                className={`Login__textfield ${themeMode}`}
                 required={true}
                 error={errors.password ? true : false}
               >
@@ -329,14 +299,9 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
                 label="Remember me"
               />
 
-              <Box>
+              <Box className={`Login__form-panel`}>
                 <Button
                   variant="contained"
-                  style={{
-                    margin: "10px auto 20px",
-                    width: "200px",
-                    backgroundColor: "#ffc93d",
-                  }}
                   onClick={handleSubmit(
                     isLoginView
                       ? loginButtonClickedHandler
@@ -350,28 +315,14 @@ const Login = ({ setLoginToken, themeMode, handleThemeModeChange }) => {
                   <span onClick={() => themeModeViewClickedHandler(false)}>
                     <Typography align="center">
                       You don&apos;t have an account?{" "}
-                      <span
-                        style={{
-                          fontWeight: "bold",
-                          cursor: "pointer",
-                        }}
-                      >
-                        Register here!
-                      </span>
+                      <span className={`subscribe`}>Register here!</span>
                     </Typography>
                   </span>
                 ) : (
                   <span onClick={() => themeModeViewClickedHandler(true)}>
                     <Typography align="center">
                       You already have an account?{" "}
-                      <span
-                        style={{
-                          fontWeight: "bold",
-                          cursor: "pointer",
-                        }}
-                      >
-                        Login here!
-                      </span>
+                      <span className={`login`}>Login here!</span>
                     </Typography>
                   </span>
                 )}


### PR DESCRIPTION
Fixes Login page input labels missing proper contrast on dark mode. #140

Screens look like this now on dark mode:

![image](https://user-images.githubusercontent.com/4129325/224827339-7170fb12-d4db-4d97-ad77-7df5f701bceb.png)


And light mode:

![image](https://user-images.githubusercontent.com/4129325/224827271-b118a2ec-ccc3-4f78-b6b8-2de1ffe27e55.png)
