### PR TITLE
Made SingleEvent info-panel text wider.

### DIFF
--- a/src/pages/Events/SingleEvent/SingleEvent.css
+++ b/src/pages/Events/SingleEvent/SingleEvent.css
@@ -14,9 +14,10 @@
 }
 
 .SingleEvent__info-panel {
+  min-width: 400px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-around;
 }
 
 .SingleEvent__image {
@@ -26,7 +27,8 @@
 }
 
 .SingleEvent__text {
-  width: 30%;
+  min-width: 200px;
+  text-align: left;
 }
 
 .SingleEvent__title {


### PR DESCRIPTION
Fixes https://github.com/gbowne1/reactsocialnetwork/issues/149

Made the text wider and aligned it to the left. Also updated the separation between image and text.

It looks like this now:

![image](https://user-images.githubusercontent.com/4129325/230882573-67cab781-864a-47a8-8962-1e46438d64d5.png)
