### PR TITLE
Add reusable component panel

### DIFF
--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -1,0 +1,109 @@
+@import url("../../variables.css");
+
+.Panel {
+  border-top-right-radius: 15px;
+  border-top-left-radius: 15px;
+  min-width: 70%;
+  max-width: 1400px;
+  min-height: 700px;
+}
+
+.Panel.light-mode {
+  background-color: var(--bg-light-100);
+  color: var(--text-dark-500);
+}
+
+.Panel.dark-mode {
+  background-color: var(--bg-dark-100);
+  color: var(--text-light-500);
+}
+
+.Panel__header {
+  max-width: 1384px;
+  height: 60px;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.Panel__header.dark-mode {
+  background-color: var(--bg-dark-900);
+  color: var(--clr-dark-mode-accent-500);
+}
+
+.Panel__header.light-mode {
+  background-color: var(--bg-light-900);
+  color: var(--clr-light-mode-accent-500);
+}
+
+.Panel__content {
+  padding: 10px;
+}
+
+.Panel__content-heading {
+  width: 100%;
+}
+
+.Close-button {
+  height: 40px;
+  width: 60px;
+  background-color: blue;
+}
+
+h1 {
+  float: left;
+  padding-top: 19px;
+  height: 45px;
+  width: 250px;
+}
+
+h2 {
+  float: left;
+  padding-top: 19px;
+  height: 45px;
+  width: 250px;
+}
+
+h3 {
+  float: left;
+  padding-top: 19px;
+  height: 45px;
+  width: 250px;
+}
+
+h4 {
+  float: left;
+  padding-top: 19px;
+  height: 45px;
+  width: 250px;
+}
+
+table {
+  margin-top: 15px;
+}
+
+.w-25 {
+  max-width: 25% !important;
+  width: 25% !important;
+  min-width: 25% !important;
+}
+
+.w-50 {
+  max-width: 50% !important;
+  width: 50% !important;
+  min-width: 50% !important;
+}
+
+.w-75 {
+  max-width: 75% !important;
+  width: 75% !important;
+  min-width: 75% !important;
+}
+
+.w-100 {
+  max-width: 100% !important;
+  width: 100% !important;
+  min-width: 100% !important;
+}

--- a/src/components/Panel/Panel.jsx
+++ b/src/components/Panel/Panel.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+import PropTypes from "prop-types";
+import CloseButton from "../CloseButton/CloseButton";
+import "./Panel.css";
+
+/**
+ *
+ * @param {string} themeMode to choose between light or dark mode.
+ * @param {number} width of the container, options are: 25, 50, 75, 100.
+ *
+ * @param {string} titleHeading to go on the header of the component.
+ * @param {string} contentHeading to go on the content of the component.
+ *
+ * @param {boolean} isOpen - boolean state use to open or close the component
+ * @param {function} setIsOpen - function used to change the state to open and close the component
+ *
+ * @returns Panel component.
+ */
+
+const Panel = ({
+  themeMode,
+  width,
+  titleHeading,
+  contentHeading,
+  isOpen,
+  setIsOpen,
+  children,
+}) => {
+  function handleClose() {
+    setIsOpen(false);
+  }
+
+  const getClassNameFromWidthProp = (width) => {
+    let widthClassName = "";
+    if (!width) return widthClassName;
+
+    if (width === 100) widthClassName = "w-100";
+    if (width === 75) widthClassName = "w-75";
+    if (width === 50) widthClassName = "w-50";
+    if (width === 25) widthClassName = "w-25";
+    return widthClassName;
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          className={`Panel ${themeMode}  ${getClassNameFromWidthProp(width)}`}
+        >
+          <div className={`Panel__header ${themeMode}`}>
+            {titleHeading && <h3 className={`Panel__title`}>{titleHeading}</h3>}
+            <CloseButton handleClose={handleClose} />
+          </div>
+          <div className={`Panel__content`}>
+            {contentHeading && (
+              <h4 className={`Panel__content-heading`}>{contentHeading}</h4>
+            )}
+            {children}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+Panel.propTypes = {
+  themeMode: PropTypes.string,
+  width: PropTypes.number,
+  titleHeading: PropTypes.string,
+  contentHeading: PropTypes.string,
+  isOpen: PropTypes.bool,
+  setIsOpen: PropTypes.func,
+  children: PropTypes.array,
+};
+
+export default Panel;

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1,26 +1,22 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import CloseButton from "../../components/CloseButton/CloseButton";
+import Panel from "../../components/Panel/Panel";
+
 import "./Dashboard.css";
 
 function Dashboard({ themeMode }) {
   const [isOpen, setIsOpen] = useState(true);
 
-  function handleClose() {
-    setIsOpen(false);
-  }
-
   return (
     <>
       {isOpen && (
-        <div className={`Dashboard ${themeMode}`}>
-          <div className={`Dashboard-header ${themeMode}`}>
-            <h3 className="Dashboard-title">Dashboard</h3>
-            <CloseButton handleClose={handleClose} />
-          </div>
-          <section className={`Dashboard-content ${themeMode}`}></section>
-          <h4>Welcome to your dashboard!</h4>
-        </div>
+        <Panel
+          themeMode={themeMode}
+          titleHeading="Dashboard"
+          contentHeading="Welcome to your dashboard!"
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+        ></Panel>
       )}
     </>
   );

--- a/src/pages/Events/Events.jsx
+++ b/src/pages/Events/Events.jsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Box, Button, MenuItem, Select, Stack } from "@mui/material";
 
-import CloseButton from "../../components/CloseButton/CloseButton";
 import SingleEvent from "./SingleEvent/SingleEvent";
 import CreateEventModal from "./CreateEventModal/CreateEventModal";
 import CustomSnackbar from "../../components/CustomSnackbar/CustomSnackbar";
+import Panel from "../../components/Panel/Panel";
 
 import saveToLocalStorage from "../../utils/saveToLocalStorage";
 import getFromLocalStorage from "../../utils/getFromLocalStorage";
@@ -28,10 +28,6 @@ const Events = ({ themeMode }) => {
   useEffect(() => {
     saveToLocalStorage("events", events);
   }, [events]);
-
-  const handleClose = () => {
-    setIsOpen(false);
-  };
 
   const handleCreateEventClose = () => {
     setCreateEventModalOpen(false);
@@ -90,52 +86,52 @@ const Events = ({ themeMode }) => {
       />
 
       {isOpen && (
-        <Box className={`Events ${themeMode}`}>
-          <Box className={`Events__header ${themeMode}`}>
-            <h3 className="Events__title">Your Events</h3>
-            <CloseButton handleClose={handleClose} />
-          </Box>
-          <Box className={`Events__content ${themeMode}`}>
-            <Box className={`Events__button-panel`}>
-              <Button
-                variant="contained"
-                onClick={handleCreateEventClicked}
-                className={`Events__creat-event-button ${themeMode}`}
-              >
-                Create new event
-              </Button>
+        <Panel
+          themeMode={themeMode}
+          titleHeading="Your Events"
+          contentHeading="Events"
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+        >
+          <Box className={`Events__button-panel`}>
+            <Button
+              variant="contained"
+              onClick={handleCreateEventClicked}
+              className={`Events__creat-event-button ${themeMode}`}
+            >
+              Create new event
+            </Button>
 
-              <Select
-                id="attendance-select"
-                className={`Events__attendance-select ${themeMode}`}
-                value={eventsFilterValue}
-                onChange={handleEventFilterClicked}
-              >
-                <MenuItem value={"Home"}>Home</MenuItem>
-                <MenuItem value={"Going"}>Going</MenuItem>
-                <MenuItem value={"Interested"}>Interested</MenuItem>
-                <MenuItem value={"Not Going"}>Not Going</MenuItem>
-              </Select>
-            </Box>
-
-            <Stack spacing={2} className={`Events__stack ${themeMode}`}>
-              {filteredEvents.map((event, i) => {
-                return (
-                  <SingleEvent
-                    themeMode={themeMode}
-                    key={i}
-                    eventKey={i}
-                    eventData={event}
-                    events={events}
-                    setEvents={setEvents}
-                    setSnackbarOptions={setSnackbarOptions}
-                    setOpenSnackbar={setOpenSnackbar}
-                  />
-                );
-              })}
-            </Stack>
+            <Select
+              id="attendance-select"
+              className={`Events__attendance-select ${themeMode}`}
+              value={eventsFilterValue}
+              onChange={handleEventFilterClicked}
+            >
+              <MenuItem value={"Home"}>Home</MenuItem>
+              <MenuItem value={"Going"}>Going</MenuItem>
+              <MenuItem value={"Interested"}>Interested</MenuItem>
+              <MenuItem value={"Not Going"}>Not Going</MenuItem>
+            </Select>
           </Box>
-        </Box>
+
+          <Stack spacing={2} className={`Events__stack ${themeMode}`}>
+            {filteredEvents.map((event, i) => {
+              return (
+                <SingleEvent
+                  themeMode={themeMode}
+                  key={i}
+                  eventKey={i}
+                  eventData={event}
+                  events={events}
+                  setEvents={setEvents}
+                  setSnackbarOptions={setSnackbarOptions}
+                  setOpenSnackbar={setOpenSnackbar}
+                />
+              );
+            })}
+          </Stack>
+        </Panel>
       )}
     </>
   );

--- a/src/pages/Friends/Friends.jsx
+++ b/src/pages/Friends/Friends.jsx
@@ -1,87 +1,77 @@
-import React, {useState} from 'react';
-import PropTypes from 'prop-types';
-import { Card } from '@mui/material';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import { Container } from '@mui/material';
-import { CardMedia } from '@mui/material';
-import { CardActions } from '@mui/material';
-import { Button } from '@mui/material';
-import CloseButton from "../../components/CloseButton/CloseButton";
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { Card } from "@mui/material";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import { Container } from "@mui/material";
+import { CardMedia } from "@mui/material";
+import { CardActions } from "@mui/material";
+import { Button } from "@mui/material";
 
-import './Friends.css';
+import "./Friends.css";
+import Panel from "../../components/Panel/Panel";
 
-function Friends({themeMode}) {
-  const [isOpen, setIsOpen] = useState(true)
+function Friends({ themeMode }) {
+  const [isOpen, setIsOpen] = useState(true);
 
-  function handleClose() {
-    setIsOpen(false);
-  }
-
-    return (
-      <>
-      { isOpen && (
-      <div
-        className={`Friends ${themeMode}`}
-      >
-        <div
-          className={`Friends-header ${themeMode}`}
+  return (
+    <>
+      {isOpen && (
+        <Panel
+          themeMode={themeMode}
+          titleHeading="Friends"
+          contentHeading="Here are your Friends!"
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
         >
-          {" "}
-          <h3 className="Friends-title">Friends</h3>
-
-          <CloseButton handleClose={handleClose} />
-        </div>
-        <h4>Here are your Friends!</h4>
-        <input
-          dir="ltr"
-          placeholder="Search"
-          aria-invalid="false"
-          aria-label="Label for text input"
-          className="search"
-          type="text"
-          value="Search">
-        </input>
-        <br />
-        <br />
-        <div>
-          <Container maxWidth="xl">
-            <Card variant="outlined" sx={{ minWidth: 275 }}>
-              <CardContent>
-                <Typography sx={{ fontSize: 19 }} gutterBottom>
-                  Friends
-				</Typography>
-			<Card sx={{ maxWidth: 198 }}>
-			<CardMedia
-				sx={{ height: 198 }}
-				image="/static/images/cards/contemplative-reptile.jpg"
-				title="a super awesome user"
-			/>
-			<CardContent>
-				<Typography gutterBottom variant="h5" component="div">
-				Awesome
-				</Typography>
-				<Typography variant="body2" color="text.secondary">
-				Add this great user
-				</Typography>
-			</CardContent>
-			<CardActions>
-				<Button size="small">Add</Button>
-				<Button size="small">Learn More</Button>
-			</CardActions>
-			</Card>
-              </CardContent>
-            </Card>
-          </Container>
-        </div>
-      </div>
-        )}
-        </>
-        );
-
+          <input
+            dir="ltr"
+            placeholder="Search"
+            aria-invalid="false"
+            aria-label="Label for text input"
+            className="search"
+            type="text"
+            value="Search"
+          ></input>
+          <br />
+          <br />
+          <div>
+            <Container maxWidth="xl">
+              <Card variant="outlined" sx={{ minWidth: 275 }}>
+                <CardContent>
+                  <Typography sx={{ fontSize: 19 }} gutterBottom>
+                    Friends
+                  </Typography>
+                  <Card sx={{ maxWidth: 198 }}>
+                    <CardMedia
+                      sx={{ height: 198 }}
+                      image="/static/images/cards/contemplative-reptile.jpg"
+                      title="a super awesome user"
+                    />
+                    <CardContent>
+                      <Typography gutterBottom variant="h5" component="div">
+                        Awesome
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        Add this great user
+                      </Typography>
+                    </CardContent>
+                    <CardActions>
+                      <Button size="small">Add</Button>
+                      <Button size="small">Learn More</Button>
+                    </CardActions>
+                  </Card>
+                </CardContent>
+              </Card>
+            </Container>
+          </div>
+        </Panel>
+      )}
+    </>
+  );
 }
 Friends.propTypes = {
-  themeMode: PropTypes.string
- };
+  themeMode: PropTypes.string,
+};
 
 export default Friends;

--- a/src/pages/HelpCenter/HelpCenter.jsx
+++ b/src/pages/HelpCenter/HelpCenter.jsx
@@ -1,98 +1,104 @@
 import React, { useState } from "react";
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
 import { Collapse, ListSubheader } from "@mui/material";
-import { ExpandLess, ExpandMore} from "@mui/icons-material";
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import helpCenterContentCategories from "../../data/json/helpCenterContentCategories.json";
 import "./HelpCenter.css";
 import PropTypes from "prop-types";
 import { Box } from "@mui/system";
 import { NavLink, Outlet } from "react-router-dom";
 
-const HelpCenter = ({themeMode}) => {
+import Panel from "../../components/Panel/Panel";
 
-    const [open, setOpen] = useState(true);
+const HelpCenter = ({ themeMode }) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [open, setOpen] = useState(true);
 
-    const handleClick = () => {
-        setOpen(!open);
-    };
-
-    const helpCenterCategories = helpCenterContentCategories.map(category => {
-
-        const {categoryName, categoryId, subcategories} = category;
-
-        return (
-            <Box 
-                sx={{display: "flex", flexDirection: "column"}}
-                key={categoryId}
-            >
-                <ListItemButton onClick={handleClick}>
-                    <ListItemText primary={categoryName} />
-                    {open ? <ExpandLess /> : <ExpandMore />}
-                </ListItemButton>
-                <Collapse in={open} timeout="auto" unmountOnExit>
-                    <List component="div" disablePadding  sx={{display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
-                            {subcategories.map(subcategory => {
-                                
-                                const {subcategoryName, subcategoryId} = subcategory;
-                                
-                                return (
-                                    <NavLink
-                                        className="Help-center__subcategory-link"
-                                        key={categoryId+subcategoryId}
-                                        to={`/help/${categoryId}/${subcategoryId}`}
-                                    >
-                                        <ListItemButton
-                                            key={subcategoryId}
-                                            sx={{ pl: 4, width: "100%" }}
-                                        >
-                                            <ListItemText primary={subcategoryName}/>
-                                        </ListItemButton>
-                                    </NavLink>
-                                )
-                                        
-                            })}
-                    </List>
-                </Collapse>
-            </Box>
-        )
-
-    }) 
-    return (
-        <div className={`Help-center ${themeMode}`}>
-            <div className={`Help-center__header ${themeMode}`}>
-                <h3>Help center</h3>
-            </div>
-            <div className="Help-center__content-wrapper">
-                <div className="Help-center__subject-picker">
-                    <List
-                        className={`Help-center__categories-list ${themeMode}`}
-                        component="nav"
-                        aria-labelledby="Help-center__categories-subheader"
-                        subheader={
-                            <ListSubheader 
-                            component="div" 
-                            id="Help-center__categories-subheader"
-                            className={`Help-center__categories-subheader ${themeMode}`}
-                            >
-                                Categories
-                            </ListSubheader>
-                        }
-                        >
-                    {helpCenterCategories}
-                    </List>
-                </div>
-                <div className="Help-center__subject-details">
-                    <Outlet/>
-                </div>
-            </div>
-        </div>
-    );
-}
-
-HelpCenter.propTypes = {
-    themeMode: PropTypes.string,
+  const handleClick = () => {
+    setOpen(!open);
   };
 
-export default HelpCenter
+  const helpCenterCategories = helpCenterContentCategories.map((category) => {
+    const { categoryName, categoryId, subcategories } = category;
+
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column" }} key={categoryId}>
+        <ListItemButton onClick={handleClick}>
+          <ListItemText primary={categoryName} />
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </ListItemButton>
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <List
+            component="div"
+            disablePadding
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            {subcategories.map((subcategory) => {
+              const { subcategoryName, subcategoryId } = subcategory;
+
+              return (
+                <NavLink
+                  className="Help-center__subcategory-link"
+                  key={categoryId + subcategoryId}
+                  to={`/help/${categoryId}/${subcategoryId}`}
+                >
+                  <ListItemButton
+                    key={subcategoryId}
+                    sx={{ pl: 4, width: "100%" }}
+                  >
+                    <ListItemText primary={subcategoryName} />
+                  </ListItemButton>
+                </NavLink>
+              );
+            })}
+          </List>
+        </Collapse>
+      </Box>
+    );
+  });
+  return (
+    <Panel
+      themeMode={themeMode}
+      width={100}
+      titleHeading="Help center"
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+    >
+      <div className="Help-center__content-wrapper">
+        <div className="Help-center__subject-picker">
+          <List
+            className={`Help-center__categories-list ${themeMode}`}
+            component="nav"
+            aria-labelledby="Help-center__categories-subheader"
+            subheader={
+              <ListSubheader
+                component="div"
+                id="Help-center__categories-subheader"
+                className={`Help-center__categories-subheader ${themeMode}`}
+              >
+                Categories
+              </ListSubheader>
+            }
+          >
+            {helpCenterCategories}
+          </List>
+        </div>
+        <div className="Help-center__subject-details">
+          <Outlet />
+        </div>
+      </div>
+    </Panel>
+  );
+};
+
+HelpCenter.propTypes = {
+  themeMode: PropTypes.string,
+};
+
+export default HelpCenter;

--- a/src/pages/Settings/Settings.jsx
+++ b/src/pages/Settings/Settings.jsx
@@ -1,26 +1,24 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { FormControlLabel, FormGroup, Switch } from "@mui/material";
-import CloseButton from "../../components/CloseButton/CloseButton";
+
+
+import Panel from "../../components/Panel/Panel";
 import "./Settings.css";
 
 function Settings({ themeMode }) {
   const [isOpen, setIsOpen] = useState(true);
 
-  
-
-  function handleClose() {
-    setIsOpen(false);
-  }
 
   return (
     <>
       {isOpen && (
-        <div className={`Settings ${themeMode}`}>
-          <div className={`Settings-header ${themeMode}`}>
-            <h3 className="Settings-title">Settings</h3>
-            <CloseButton handleClose={handleClose} />
-          </div>
+        <Panel
+          themeMode={themeMode}
+          titleHeading="Settings"
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+        >
           <div className="Settings-tab-groups-container">
             <div className="Settings-tab-group">
               <h3 className="Settings-tab-group-header">
@@ -71,7 +69,7 @@ function Settings({ themeMode }) {
 
             <hr />
           </div>
-        </div>
+        </Panel>
       )}
     </>
   );


### PR DESCRIPTION
Here is the component Panel created as per https://github.com/gbowne1/reactsocialnetwork/issues/173

I replaced the cases where we already had component panels with the new one.

I also left the help center panel with 100% as it was before, while all the others have 70%.

Components currently look like this:

![image](https://user-images.githubusercontent.com/4129325/233661620-2caf296f-a1dc-4bfc-976c-c4c4628c8ecc.png)

![image](https://user-images.githubusercontent.com/4129325/233661670-97e085ae-b447-458b-8ec6-056c9af98e88.png)

![image](https://user-images.githubusercontent.com/4129325/233661704-05bb4e40-faa2-4f2f-9963-20dc0229f447.png)

![image](https://user-images.githubusercontent.com/4129325/233661745-26996dc6-9618-4512-86f8-d361e393e3eb.png)

![image](https://user-images.githubusercontent.com/4129325/233661767-3f0b38af-2f29-40d9-ab1f-f87499a71cc7.png)

