### PR TITLE
[Bugfix] Fix outdated and deprecated babel-eslint parser

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    "@babel/preset-react",
+    "@babel/preset-env"
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,9 @@
     "react",
     "prettier"
   ],
+  "parserOptions": {
+    "requireConfigFile": true
+  },
   "rules": {
     "prettier/prettier": "error",
     "react/jsx-uses-react": "off",

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,9 +4,9 @@ We acknowledge the following people for their dedications to make this project a
 
 | Name                  | GitHub                                           | Social                                                  |
 | --------------------- | ------------------------------------------------ | ------------------------------------------------------- |
-| Parth Gera            | [@Parth1125](https://github.com/Parth1125)       | https://www.linkedin.com/in/parthgera326/               |
-| Dylan Clarry          | [@Dylan-Clarry](https://github.com/Dylan-Clarry) | https://www.linkedin.com/in/dylanclarry/                |
-| Pawel Kurek           | [@pawel975](https://github.com/pawel975)         | https://www.linkedin.com/in/pawe%C5%82-kurek-7aab5424b/ |
+| Parth Gera            | [@Parth1125](https://github.com/Parth1125)       | <https://www.linkedin.com/in/parthgera326/>         |
+| Dylan Clarry          | [@Dylan-Clarry](https://github.com/Dylan-Clarry) | <https://www.linkedin.com/in/dylanclarry/>               |
+| Pawel Kurek           | [@pawel975](https://github.com/pawel975)         | <https://www.linkedin.com/in/pawe%C5%82-kurek-7aab5424b/> |
 | Kevin Lourenço        | [@cidrokp1]                                      |
 | Tarun Samanta         | [@tarunsamanta2k20]                              |
 |                       | [@elmehdi121]                                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/react": "^13.4.0",
 				"@testing-library/user-event": "^14.4.3",
-				"babel-eslint": "^10.1.0",
 				"babel-loader": "^9.1.2",
 				"dayjs": "^1.11.7",
 				"dotenv": "^16.0.3",
+				"eslint": "^8.0.0",
 				"eslint-config-prettier": "^8.8.0",
 				"eslint-config-react-app": "^7.0.1",
 				"eslint-plugin-prettier": "^4.2.1",
@@ -43,6 +43,7 @@
 				"yup-password": "^0.2.2"
 			},
 			"devDependencies": {
+				"@babel/eslint-parser": "^7.21.8",
 				"@testing-library/dom": "^9.2.0",
 				"jest-watch-typeahead": "^0.6.5",
 				"react-test-renderer": "^18.2.0"
@@ -52,6 +53,17 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
 			"integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA=="
+		},
+		"node_modules/@alloc/quick-lru": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.2.1",
@@ -114,9 +126,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
-			"integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
+			"version": "7.21.8",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.8.tgz",
+			"integrity": "sha512-HLhI+2q+BP3sf78mFUZNCGc10KEmoUqtUT1OCdMZsN+qr4qFeLUod62/zAnF3jNQstwyasDkZnVXwfK2Bml7MQ==",
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
 				"eslint-visitor-keys": "^2.1.0",
@@ -4712,9 +4724,9 @@
 			}
 		},
 		"node_modules/@types/connect-history-api-fallback": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
-			"integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+			"integrity": "sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==",
 			"dependencies": {
 				"@types/express-serve-static-core": "*",
 				"@types/node": "*"
@@ -4755,13 +4767,14 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.17.33",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-			"integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+			"version": "4.17.34",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.34.tgz",
+			"integrity": "sha512-fvr49XlCGoUj2Pp730AItckfjat4WNb0lb3kfrLWffd+RLeoGAMsq7UOy04PAPtoL01uKwcp6u8nhzpgpDYr3w==",
 			"dependencies": {
 				"@types/node": "*",
 				"@types/qs": "*",
-				"@types/range-parser": "*"
+				"@types/range-parser": "*",
+				"@types/send": "*"
 			}
 		},
 		"node_modules/@types/graceful-fs": {
@@ -4850,9 +4863,9 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
 		},
 		"node_modules/@types/mime": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-			"integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
 		},
 		"node_modules/@types/node": {
 			"version": "18.16.0",
@@ -4945,6 +4958,15 @@
 			"version": "7.3.13",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
+		},
+		"node_modules/@types/send": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/serve-index": {
 			"version": "1.9.1",
@@ -5992,26 +6014,6 @@
 				"deep-equal": "^2.0.5"
 			}
 		},
-		"node_modules/babel-eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-			"deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"peerDependencies": {
-				"eslint": ">= 4.12.1"
-			}
-		},
 		"node_modules/babel-jest": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -6503,6 +6505,11 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/camel-case/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
 		"node_modules/camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -6759,12 +6766,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-			"engines": {
-				"node": ">= 12"
-			}
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"node_modules/common-path-prefix": {
 			"version": "3.0.0",
@@ -7683,6 +7687,11 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/dot-case/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
 		"node_modules/dotenv": {
 			"version": "16.0.3",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -8101,6 +8110,23 @@
 				"eslint": "^8.0.0"
 			}
 		},
+		"node_modules/eslint-config-react-app/node_modules/eslint-plugin-flowtype": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
+			"integrity": "sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==",
+			"dependencies": {
+				"lodash": "^4.17.21",
+				"string-natural-compare": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"@babel/plugin-syntax-flow": "^7.14.5",
+				"@babel/plugin-transform-react-jsx": "^7.14.9",
+				"eslint": "^8.1.0"
+			}
+		},
 		"node_modules/eslint-import-resolver-node": {
 			"version": "0.3.7",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
@@ -8141,23 +8167,6 @@
 			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dependencies": {
 				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/eslint-plugin-flowtype": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
-			"integrity": "sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==",
-			"dependencies": {
-				"lodash": "^4.17.21",
-				"string-natural-compare": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"@babel/plugin-syntax-flow": "^7.14.5",
-				"@babel/plugin-transform-react-jsx": "^7.14.9",
-				"eslint": "^8.1.0"
 			}
 		},
 		"node_modules/eslint-plugin-import": {
@@ -8373,14 +8382,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/eslint-webpack-plugin": {
@@ -9517,6 +9518,13 @@
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
+		"node_modules/growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/gzip-size": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -9726,6 +9734,14 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/html-minifier-terser/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/html-webpack-plugin": {
@@ -13378,6 +13394,11 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/lower-case/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -13661,6 +13682,11 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/no-case/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -13673,6 +13699,57 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
+		},
+		"node_modules/node-notifier": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+			"integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"growly": "^1.3.0",
+				"is-wsl": "^2.2.0",
+				"semver": "^7.3.5",
+				"shellwords": "^0.1.1",
+				"uuid": "^8.3.2",
+				"which": "^2.0.2"
+			}
+		},
+		"node_modules/node-notifier/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-notifier/node_modules/semver": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-notifier/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.10",
@@ -14007,6 +14084,11 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/param-case/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -14056,6 +14138,11 @@
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
 			}
+		},
+		"node_modules/pascal-case/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -14658,16 +14745,16 @@
 			}
 		},
 		"node_modules/postcss-import": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-			"integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
 				"read-cache": "^1.0.0",
 				"resolve": "^1.1.7"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
@@ -14719,15 +14806,15 @@
 			}
 		},
 		"node_modules/postcss-load-config": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+			"integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
 			"dependencies": {
 				"lilconfig": "^2.0.5",
-				"yaml": "^1.10.2"
+				"yaml": "^2.1.1"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 14"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -14744,6 +14831,14 @@
 				"ts-node": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/postcss-load-config/node_modules/yaml": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/postcss-loader": {
@@ -14967,11 +15062,11 @@
 			}
 		},
 		"node_modules/postcss-nested": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
-			"integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+			"integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.10"
+				"postcss-selector-parser": "^6.0.11"
 			},
 			"engines": {
 				"node": ">=12.0"
@@ -15365,9 +15460,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-			"integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+			"version": "6.0.12",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
+			"integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -15662,17 +15757,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/raf": {
 			"version": "3.4.1",
@@ -17231,6 +17315,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -17868,50 +17959,41 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
-			"integrity": "sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
+			"integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
 			"dependencies": {
+				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
 				"chokidar": "^3.5.3",
-				"color-name": "^1.1.4",
 				"didyoumean": "^1.2.2",
 				"dlv": "^1.1.3",
 				"fast-glob": "^3.2.12",
 				"glob-parent": "^6.0.2",
 				"is-glob": "^4.0.3",
-				"jiti": "^1.17.2",
-				"lilconfig": "^2.0.6",
+				"jiti": "^1.18.2",
+				"lilconfig": "^2.1.0",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"object-hash": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.0.9",
-				"postcss-import": "^14.1.0",
-				"postcss-js": "^4.0.0",
-				"postcss-load-config": "^3.1.4",
-				"postcss-nested": "6.0.0",
+				"postcss": "^8.4.23",
+				"postcss-import": "^15.1.0",
+				"postcss-js": "^4.0.1",
+				"postcss-load-config": "^4.0.1",
+				"postcss-nested": "^6.0.1",
 				"postcss-selector-parser": "^6.0.11",
 				"postcss-value-parser": "^4.2.0",
-				"quick-lru": "^5.1.1",
-				"resolve": "^1.22.1",
-				"sucrase": "^3.29.0"
+				"resolve": "^1.22.2",
+				"sucrase": "^3.32.0"
 			},
 			"bin": {
 				"tailwind": "lib/cli.js",
 				"tailwindcss": "lib/cli.js"
 			},
 			"engines": {
-				"node": ">=12.13.0"
-			},
-			"peerDependencies": {
-				"postcss": "^8.0.9"
+				"node": ">=14.0.0"
 			}
-		},
-		"node_modules/tailwindcss/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
@@ -18038,11 +18120,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
-		},
-		"node_modules/terser/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -18212,9 +18289,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -18229,11 +18306,6 @@
 			"peerDependencies": {
 				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
 				"@babel/eslint-parser": "^7.21.8",
 				"@testing-library/dom": "^9.2.0",
 				"jest-watch-typeahead": "^0.6.5",
+				"prettier": "^2.8.8",
 				"react-test-renderer": "^18.2.0"
 			}
 		},
@@ -15570,7 +15571,6 @@
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
 			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-			"peer": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"@babel/eslint-parser": "^7.21.8",
 		"@testing-library/dom": "^9.2.0",
 		"jest-watch-typeahead": "^0.6.5",
+		"prettier": "^2.8.8",
 		"react-test-renderer": "^18.2.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^13.4.0",
 		"@testing-library/user-event": "^14.4.3",
-		"babel-eslint": "^10.1.0",
 		"babel-loader": "^9.1.2",
 		"dayjs": "^1.11.7",
 		"dotenv": "^16.0.3",
+		"eslint": "^8.0.0",
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-config-react-app": "^7.0.1",
 		"eslint-plugin-prettier": "^4.2.1",
@@ -68,9 +68,9 @@
 		]
 	},
 	"devDependencies": {
+		"@babel/eslint-parser": "^7.21.8",
 		"@testing-library/dom": "^9.2.0",
 		"jest-watch-typeahead": "^0.6.5",
-		"react-test-renderer": "^18.2.0",
-    "eslint": "^7.21.0"
+		"react-test-renderer": "^18.2.0"
 	}
 }


### PR DESCRIPTION
This PR will fix the outdated babel-eslint parser so that you will not get a warning about imports. This should fix the remaining bug(s) for ESLint and Prettier and Babel.

I uninstalled the deprecated parser.  This should not need any more fixes.

Note: Additionally this commit & PR fixes the links in CONTRIBUTORS.md file. Not a breaking change so included this here.

