### PR TITLE
Cookie accept not working

### DIFF
--- a/client/src/components/CookieModal/CookieModal.jsx
+++ b/client/src/components/CookieModal/CookieModal.jsx
@@ -34,7 +34,7 @@ const CookieModal = () => {
   };
 
   return cookiesAccepted ? null : (
-    <Modal open={isOpen} onClose={closeCookieModal} className="modal-box">
+    <Modal open={isOpen} onClose={closeCookieModal} className="modal-box" data-testid="cookie-modal">
       <>
         <Card className="cookies-card">
           <CardHeader title="Our Website Uses Cookies" />
@@ -76,6 +76,7 @@ const CookieModal = () => {
                 color="secondary"
                 className="necessarybtn"
                 onClick={closeCookieModal}
+                data-testid="cookie-modal-accept-necessary-button"
               >
                 Accept Necessary
               </Button>
@@ -84,6 +85,7 @@ const CookieModal = () => {
                 color="primary"
                 className="acceptallbtn"
                 onClick={closeCookieModal}
+                data-testid="cookie-modal-accept-all-button"
               >
                 Accept All
               </Button>

--- a/client/src/components/CookieModal/CookieModal.jsx
+++ b/client/src/components/CookieModal/CookieModal.jsx
@@ -9,8 +9,13 @@ import {
   Modal,
 } from "@mui/material";
 import HighlightOffIcon from "@mui/icons-material/HighlightOff";
+import getFromLocalStorage from "../../utils/getFromLocalStorage";
+import saveToLocalStorage from "../../utils/saveToLocalStorage";
 
 const CookieModal = () => {
+  // State used to ONLY show cookie modal in case cookies have not been accepted.
+  const [cookiesAccepted] = useState(getFromLocalStorage("cookiesAccepted"));
+
   const [isOpen, setIsOpen] = useState(false);
   const [showLearnMoreLink] = useState(false);
 
@@ -23,15 +28,13 @@ const CookieModal = () => {
   }, []);
 
   const closeCookieModal = () => {
+    // Save cookie state on localStorage.
+    saveToLocalStorage("cookiesAccepted", true);
     setIsOpen(false);
-  }
+  };
 
-  return (
-    <Modal
-      open={isOpen}
-      onClose={closeCookieModal}
-      className="modal-box"
-    >
+  return cookiesAccepted ? null : (
+    <Modal open={isOpen} onClose={closeCookieModal} className="modal-box">
       <>
         <Card className="cookies-card">
           <CardHeader title="Our Website Uses Cookies" />
@@ -45,10 +48,12 @@ const CookieModal = () => {
           <CardContent>
             <div className="card-content">
               <p>We collect user data to provide better user experience.</p>
-              {showLearnMoreLink && <a href="!#" style={{ color: "black" }}>
-                {" "}
-                Learn more about how we use cookies.
-              </a>}
+              {showLearnMoreLink && (
+                <a href="!#" style={{ color: "black" }}>
+                  {" "}
+                  Learn more about how we use cookies.
+                </a>
+              )}
             </div>
             <hr />
             <div className="cookies-card-bottom">

--- a/client/src/components/CookieModal/CookieModal.jsx
+++ b/client/src/components/CookieModal/CookieModal.jsx
@@ -12,6 +12,7 @@ import HighlightOffIcon from "@mui/icons-material/HighlightOff";
 
 const CookieModal = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [showLearnMoreLink] = useState(false);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -21,12 +22,14 @@ const CookieModal = () => {
     return () => clearTimeout(timeout);
   }, []);
 
+  const closeCookieModal = () => {
+    setIsOpen(false);
+  }
+
   return (
     <Modal
       open={isOpen}
-      onClose={() => {
-        setIsOpen(false);
-      }}
+      onClose={closeCookieModal}
       className="modal-box"
     >
       <>
@@ -42,10 +45,10 @@ const CookieModal = () => {
           <CardContent>
             <div className="card-content">
               <p>We collect user data to provide better user experience.</p>
-              <a href="!#" style={{ color: "black" }}>
+              {showLearnMoreLink && <a href="!#" style={{ color: "black" }}>
                 {" "}
                 Learn more about how we use cookies.
-              </a>
+              </a>}
             </div>
             <hr />
             <div className="cookies-card-bottom">
@@ -67,6 +70,7 @@ const CookieModal = () => {
                 variant="contained"
                 color="secondary"
                 className="necessarybtn"
+                onClick={closeCookieModal}
               >
                 Accept Necessary
               </Button>
@@ -74,6 +78,7 @@ const CookieModal = () => {
                 variant="contained"
                 color="primary"
                 className="acceptallbtn"
+                onClick={closeCookieModal}
               >
                 Accept All
               </Button>

--- a/e2e/cypress/e2e/cookie-modal.cy.js
+++ b/e2e/cypress/e2e/cookie-modal.cy.js
@@ -1,0 +1,34 @@
+/// <reference types="cypress" />
+
+describe("Cookie Modal tests", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/");
+  });
+
+  it("should display cookie modal, close it when clicking'Accept Necessary' and not display again after page reload", () => {
+    cy.get("[data-testid=cookie-modal]").should("be.visible");
+    cy.get("[data-testid=cookie-modal-accept-necessary-button]").click();
+    cy.get("[data-testid=cookie-modal]").should("not.exist");
+
+    cy.reload();
+    cy.get("[data-testid=cookie-modal]").should("not.exist");
+  });
+
+  it("should display cookie modal, close it when clicking'Accept All' and not display again after page reload", () => {
+    cy.get("[data-testid=cookie-modal]").should("be.visible");
+    cy.get("[data-testid=cookie-modal-accept-all-button]").click();
+    cy.get("[data-testid=cookie-modal]").should("not.exist");
+
+    cy.reload();
+    cy.get("[data-testid=cookie-modal]").should("not.exist");
+  });
+
+  it("should display cookie modal, close it when clicking on the X button and display it after page relaod", () => {
+    cy.get("[data-testid=cookie-modal]").should("be.visible");
+    cy.get("[data-testid=cookie-modal-close-button]").click();
+    cy.get("[data-testid=cookie-modal]").should("not.exist");
+
+    cy.reload();
+    cy.get("[data-testid=cookie-modal]").should("be.visible");
+  });
+});


### PR DESCRIPTION
Added a fix for https://github.com/gbowne1/reactsocialnetwork/issues/220

Now both accept buttons on the cookie modal will close it and will also saved a "cookiesAccepted" state in localstorage that will be checked when loading the app, if the state is true then cookies modal will not be shown.

Note: only clicking either of the accept buttons saves this state, if you close the cookie modal by clicking on  the X button this
will not be interpreted as accepted, and the modal will re-appear on next page reload.

