### PR TITLE
[Bugfix] ESlint Shared config bug with shared-config

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -3,7 +3,6 @@
   "extends": [
     "react-app",
     "react-app/jest",
-    "shared-config"
   ],
   "plugins": [
     "react",


### PR DESCRIPTION
This PR includes fixes for this shared-config error from ESLint you get when starting the app.

![Screenshot 2023-06-13 at 16-04-52 React Social Media App](https://github.com/gbowne1/reactsocialnetwork/assets/47549872/7320889d-d4a0-46ee-959e-034adf570788)

This is an artifact of us trying to sort out the ESLint and Prettier configuration we tried to do which got overly complex.

We do not need shared-config.  Installing shared-config did not fix this, so opted for removing the extend instead and it went away.