### PR TITLE
Configured dependabot to update packages #294

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/client"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - "npm"
+      - "dependencies"
+      - "need-review"
+      - "frontend"
+  - package-ecosystem: npm
+    directory: "/server"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - "npm"
+      - "dependencies"
+      - "need-review"
+      - "backend"
+  - package-ecosystem: npm
+    directory: "/e2e"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    labels:
+      - "npm"
+      - "dependencies"
+      - "need-review"
+      - "e2e"


### PR DESCRIPTION
**Summary**
Configured dependabot to update the packages by weekly in client, server and e2e packages. Max of 2 PRs will be created in client/server and 1 will be created e2e if there is any new updates available.

Now, I have a configured a bare minimum dependabot setup to update the packages. We can later add or update the configuration in the dependabot.yml file.

Here is the config options for dependabot: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file

**Note**
As of now, we there is no option to using glob patterns or providing multiple path to the dependabot to pick the package.json in the nested folders. So for now, we have to duplicate the update config for each package folders.

Dependabot issue can be found here: https://github.com/dependabot/dependabot-core/issues/2178 https://github.com/dependabot/dependabot-core/issues/3951