### PR TITLE
bugfix : [Bug]: Login page validation error messages not visible in dark theme

### DIFF
--- a/client/src/pages/Login/Login.css
+++ b/client/src/pages/Login/Login.css
@@ -19,21 +19,21 @@
 }
 
 .Login__form {
-    border: 1px solid;
-    border-radius: 10px;
-    margin: 0 auto;
-    max-width: 600px;
-    width: 100%;
-    padding: 20px;
+  border: 1px solid;
+  border-radius: 10px;
+  margin: 0 auto;
+  max-width: 600px;
+  width: 100%;
+  padding: 20px;
 }
 
 .Login__form.light-mode {
-    background: rgba(255, 255, 255, 0.21);
-    border-radius: 16px;
-    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(5px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.21);
+  border-radius: 16px;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .Login__form.dark-mode {
@@ -43,6 +43,7 @@
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
   border: 1px solid rgba(0, 0, 0, 0.3);
+  color: #f87171 !important;
 }
 
 .Login__textfield.dark-mode label {


### PR DESCRIPTION
[Bug]: Login page validation error messages not visible in dark theme https://github.com/gbowne1/reactsocialnetwork/issues/445

Added contrast color for validation error messages in dark mode.
this PR closed [Bug] https://github.com/gbowne1/reactsocialnetwork/issues/445

validation error message before bug fix.
![ErrorValidationDarktheme](https://github.com/user-attachments/assets/43093d3a-e4f9-446f-b7ae-e892e2727d3c)
validation error message after bug fix.
![image](https://github.com/user-attachments/assets/518fec8a-58ec-4455-9105-80efa21f1653)
